### PR TITLE
Fixed typings issue for Typescript 2.6

### DIFF
--- a/typings/transcoders/Opus.d.ts
+++ b/typings/transcoders/Opus.d.ts
@@ -15,4 +15,9 @@ export class OpusStream extends Transform {
 export class Encoder extends OpusStream {}
 export class Decoder extends OpusStream {}
 
-export default { Encoder, Decoder }
+declare let _default: {
+  Encoder: Encoder,
+  Decoder: Decoder,
+}
+
+export default _default;


### PR DESCRIPTION
In Typescript 2.6 you get the error `The expression of an export assignment must be an identifier or qualified name in an ambient context.`

https://github.com/Microsoft/TypeScript/pull/18444