### PR TITLE
docs: mark args as part of options in FFmpeg and remove superflous be in opus.Encoder

### DIFF
--- a/src/core/FFmpeg.js
+++ b/src/core/FFmpeg.js
@@ -11,7 +11,7 @@ class FFmpeg extends Duplex {
    * Creates a new FFmpeg transform stream
    * @memberof core
    * @param {Object} options Options you would pass to a regular Transform stream, plus an `args` option
-   * @param {Array<string>} args Arguments to pass to FFmpeg
+   * @param {Array<string>} options.args Arguments to pass to FFmpeg
    * @example
    * // By default, if you don't specify an input (`-i ...`) prism will assume you're piping a stream into it.
    * const transcoder = new prism.FFmpeg({

--- a/src/opus/Opus.js
+++ b/src/opus/Opus.js
@@ -152,7 +152,7 @@ class Encoder extends OpusStream {
  * An Opus decoder stream.
  *
  * Note that any stream you pipe into this must be in
- * [object mode](https://nodejs.org/api/stream.html#stream_object_mode) and should be output Opus packets.
+ * [object mode](https://nodejs.org/api/stream.html#stream_object_mode) and should output Opus packets.
  * @extends opus.OpusStream
  * @memberof opus
  * @example


### PR DESCRIPTION
- Currently `core.FFmpeg` documents two parameters, those were intended to be one.
Added a `options.` to mark it as such.

- Removed a superfluous 'be' in opus.Decoder's docstring.

On another note regarding `core.FFmpeg`:
The typings mark the [options](https://github.com/amishshah/prism-media/blob/master/typings/transcoders/FFmpeg.d.ts#L10) as optional (as well as [args](https://github.com/amishshah/prism-media/blob/master/typings/transcoders/FFmpeg.d.ts#L5)).
The code treats them as [optional](https://github.com/amishshah/prism-media/blob/master/src/core/FFmpeg.js#L29) too, [both](https://github.com/amishshah/prism-media/blob/master/src/core/FFmpeg.js#L74). (This might be intended to get FFmpeg to emit that error though)

I can't think of any way for this to work without any parameters. (FFmpeg without arguments, that is)
Should the typings get updates as well to reflect that, or am I missing something?
If not the docs should be updated to reflect that they are optional.