### PR TITLE
Fix the typings.

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,6 +1,6 @@
 export * from './core';
-import opus from './opus';
-import vorbis from './vorbis';
+import * as opus from './opus';
+import * as vorbis from './vorbis';
 
 export {
   opus,


### PR DESCRIPTION
Reopen of #22 after accidental fork deletion and closing due to a solution arising that ended up not working.

Old description:
I was getting an error whilst compiling my TypeScript telling me that there are no default exports for the typings, meaning that you weren't importing anything. You'd need to import everything in that file and then export it, rather than exporting the default.