### PR TITLE
Export OpusStream type

### DIFF
--- a/typings/opus.d.ts
+++ b/typings/opus.d.ts
@@ -6,7 +6,7 @@ interface OpusOptions {
   rate: number
 }
 
-class OpusStream extends Transform {
+export class OpusStream extends Transform {
   public encoder: any; // TODO: type opusscript/node-opus
 
   constructor(options?: OpusOptions);


### PR DESCRIPTION
Heya 👋,

I just started with Typescript and ran into an issue while trying run the compiler on a piece of code that uses library. It might be just me so feel free to close this if the change requested is an error on my side 🙈 

Reproduction:
```typescript
import { FFmpeg } from 'prism-media';
let options = { args: ['-ar', '48000', '-ac', '2'] };
const transcoder = new FFmpeg(options);
```

Error:
```
node_modules/prism-media/typings/opus.d.ts:9:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

9 class OpusStream extends Transform {
```

Let me know if you need anything changed 😄 Thanks for the library