### PR TITLE
Fix ffmpeg-static v3.x compatible

### DIFF
--- a/src/core/FFmpeg.js
+++ b/src/core/FFmpeg.js
@@ -109,7 +109,10 @@ class FFmpeg extends Duplex {
    */
   static getInfo(force = false) {
     if (FFMPEG.command && !force) return FFMPEG;
-    const sources = [() => require('ffmpeg-static').path, 'ffmpeg', 'avconv', './ffmpeg', './avconv'];
+    const sources = [() => {
+      const ffmpegStatic = require('ffmpeg-static');
+      return ffmpegStatic.path || ffmpegStatic;
+    }, 'ffmpeg', 'avconv', './ffmpeg', './avconv'];
     for (let source of sources) {
       try {
         if (typeof source === 'function') source = source();

--- a/typings/opus.d.ts
+++ b/typings/opus.d.ts
@@ -6,7 +6,7 @@ interface OpusOptions {
   rate: number
 }
 
-class OpusStream extends Transform {
+export class OpusStream extends Transform {
   public encoder: any; // TODO: type opusscript/node-opus
 
   constructor(options?: OpusOptions);


### PR DESCRIPTION
As of ffmpeg-static v3.0.0, this has been changed to direct export without exporting the path attribute.
See https://github.com/eugeneware/ffmpeg-static/commit/c3b1dc71804ac4c5ef0c953a190c2c9528a965b1
