### PR TITLE
types(VolumeTransformer): extended it to Transform

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -27,7 +27,7 @@ export interface VolumeOptions {
   volume?: number
 }
 
-export class VolumeTransformer {
+export class VolumeTransformer extends Transform {
   public volume: number;
 
   constructor(options: VolumeOptions);


### PR DESCRIPTION
Since VolumeTransformer wasnt assignable to WritableStream it needed to be extended correctly in the types