### PR TITLE
Catch and Propagate Opus Decoding errors

### DIFF
--- a/src/opus/Opus.js
+++ b/src/opus/Opus.js
@@ -203,9 +203,9 @@ class Decoder extends OpusStream {
     try {
       this.push(this._decode(chunk));
     } catch (e) {
-      done(e);
+      return done(e);
     }
-    done();
+    return done();
   }
 }
 

--- a/src/opus/Opus.js
+++ b/src/opus/Opus.js
@@ -200,8 +200,12 @@ class Decoder extends OpusStream {
       this.emit('tags', chunk);
       return done();
     }
-    this.push(this._decode(chunk));
-    return done();
+    try {
+      this.push(this._decode(chunk));
+    } catch (e) {
+      done(e);
+    }
+    done();
   }
 }
 


### PR DESCRIPTION
- Surround the decoding with a try-catch
- Propagate the error through the stream callback.  This allows the following piece of code: 

```
        let audio = connection.receiver.createStream(user, { mode: 'opus', end: 'manual' })
        const decoder = new opus.Decoder({ channels: 2, rate: 48000, frameSize: 960 })
        audio.pipe(decoder).on('error', (err => {
            console.log('error occured')
        }))
```

This allows the error found in this [issue](https://github.com/discordjs/discord.js/issues/5105) to not crash when a user is on browser.  It still requires users to manually decode the opus stream, unless the `discordjs` library is modified to allow users to pass their own exception handler into the `createStream` method.
