### PR TITLE
feat(opus): custom loaders

### DIFF
--- a/src/ffmpeg/loader.ts
+++ b/src/ffmpeg/loader.ts
@@ -9,9 +9,9 @@ interface FFmpegInfo {
 	version: string;
 }
 
-let cached: FFmpegInfo | undefined = undefined;
+let cached: FFmpegInfo | undefined;
 
-const VERSION_REGEX = new RegExp(/version (.+) Copyright/im);
+const VERSION_REGEX = /version (.+) Copyright/im;
 
 const SOURCES: (() => string)[] = [
 	() => {

--- a/src/ogg/OpusDemuxer.ts
+++ b/src/ogg/OpusDemuxer.ts
@@ -3,10 +3,9 @@ import { Transform, TransformCallback, TransformOptions } from 'stream';
 const OGG_PAGE_HEADER_SIZE = 26;
 const STREAM_STRUCTURE_VERSION = 0;
 
-const charCode = (x: string) => x.charCodeAt(0);
-const OGGS_HEADER = Buffer.from([...'OggS'].map(charCode));
-const OPUS_HEAD = Buffer.from([...'OpusHead'].map(charCode));
-const OPUS_TAGS = Buffer.from([...'OpusTags'].map(charCode));
+const OGGS_HEADER = Buffer.from('OggS');
+const OPUS_HEAD = Buffer.from('OpusHead');
+const OPUS_TAGS = Buffer.from('OpusTags');
 
 export class OggOpusDemuxer extends Transform {
 	private _remainder?: Buffer;

--- a/src/opus/OpusDecoderStream.ts
+++ b/src/opus/OpusDecoderStream.ts
@@ -1,9 +1,8 @@
 import type { TransformCallback } from 'stream';
 import { OpusStream, OpusStreamConfig } from './OpusStream';
 
-const charCode = (x: string) => x.charCodeAt(0);
-const OPUS_HEAD = Buffer.from([...'OpusHead'].map(charCode));
-const OPUS_TAGS = Buffer.from([...'OpusTags'].map(charCode));
+const OPUS_HEAD = Buffer.from('OpusHead');
+const OPUS_TAGS = Buffer.from('OpusTags');
 
 export class OpusDecoderStream extends OpusStream {
 	public opusHead?: Buffer;

--- a/src/webm/WebmOpusDemuxer.ts
+++ b/src/webm/WebmOpusDemuxer.ts
@@ -1,7 +1,7 @@
 import { TransformOptions } from 'stream';
 import { WebmBaseDemuxer } from './WebmBaseDemuxer';
 
-const OPUS_HEAD = Buffer.from([...'OpusHead'].map((x) => x.charCodeAt(0)));
+const OPUS_HEAD = Buffer.from('OpusHead');
 
 export class WebmOpusDemuxer extends WebmBaseDemuxer {
 	protected _checkHead(data: Buffer) {

--- a/src/webm/WebmVorbisDemuxer.ts
+++ b/src/webm/WebmVorbisDemuxer.ts
@@ -1,7 +1,7 @@
 import { TransformOptions } from 'stream';
 import { WebmBaseDemuxer } from './WebmBaseDemuxer';
 
-const VORBIS_HEAD = Buffer.from([...'vorbis'].map((x) => x.charCodeAt(0)));
+const VORBIS_HEAD = Buffer.from('vorbis');
 
 export class WebmVorbisDemuxer extends WebmBaseDemuxer {
 	protected _checkHead(data: Buffer) {


### PR DESCRIPTION
This will allow to have additional opus loaders.
There is also a very small refactoring (like `Buffer.from([...'OpusHead'].map(charCode)])` -> `Buffer.from('OpusHead')`).