### PR TITLE
Adds bounds check to guard against infinite loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-media",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Easy-to-use stream-based media transcoding",
   "main": "src/index.js",
   "types": "typings/index.d.ts",

--- a/src/core/WebmBase.js
+++ b/src/core/WebmBase.js
@@ -205,6 +205,9 @@ const TAGS = WebmBaseDemuxer.TAGS = { // value is true if the element has childr
 module.exports = WebmBaseDemuxer;
 
 function vintLength(buffer, index) {
+  if (index < 0 || index > buffer.length - 1) {
+    return TOO_SHORT;
+  }
   let i = 0;
   for (; i < 8; i++) if ((1 << (7 - i)) & buffer[index]) break;
   i++;


### PR DESCRIPTION
Lack of bounds checking was occasionally causing an infinite loop when using the WebM demuxer.