### PR TITLE
fix: peer dependency opus

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "testURL": "http://localhost/"
   },
   "peerDependencies": {
-    "@discordjs/opus": "^0.5.0",
+    "@discordjs/opus": ">=0.5.0",
     "ffmpeg-static": "^4.2.7 || ^3.0.0 || ^2.4.0",
     "node-opus": "^0.3.3",
     "opusscript": "^0.0.8"


### PR DESCRIPTION
await discordjs/node-pre-gyp/pull/6
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: prism-media@1.3.2
npm ERR! Found: @discordjs/opus@0.7.0
npm ERR! node_modules/@discordjs/opus
npm ERR!   dev @discordjs/opus@"^0.7.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peerOptional @discordjs/opus@"^0.5.0" from prism-media@1.3.2
npm ERR! node_modules/prism-media
npm ERR!   prism-media@"^1.3.2" from the root project
npm ERR!   prism-media@"^1.3.2" from @discordjs/voice@0.7.5
npm ERR!   node_modules/@discordjs/voice
npm ERR!     dev @discordjs/voice@"^0.7.5" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: @discordjs/opus@0.5.3
npm ERR! node_modules/@discordjs/opus
npm ERR!   peerOptional @discordjs/opus@"^0.5.0" from prism-media@1.3.2
npm ERR!   node_modules/prism-media
npm ERR!     prism-media@"^1.3.2" from the root project
npm ERR!     prism-media@"^1.3.2" from @discordjs/voice@0.7.5
npm ERR!     node_modules/@discordjs/voice
npm ERR!       dev @discordjs/voice@"^0.7.5" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```