### PR TITLE
fix: Correct @djs/opus version restrictions

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     }
   },
   "peerDependencies": {
-    "@discordjs/opus": "^0.8.0",
+    "@discordjs/opus": ">=0.8.0 <1.0.0",
     "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
     "node-opus": "^0.3.3",
     "opusscript": "^0.0.8"


### PR DESCRIPTION
In [node-semver](https://github.com/npm/node-semver#caret-ranges-123-025-004), the caret "Allows changes that do not modify the left-most non-zero element in the [major, minor, patch] tuple". That is, `0.x` versions are considered breaking, and thus not valid. I'm fairly sure this was just an oversight, as all `0.x` versions of djs/opus to date have been non-breaking. 

This change just modifies the dependency version to allow all `0.x` versions, breaking at `1.0.0`

Fixes \#109:
- #109 