### PR TITLE
Add 'output' option and fix emit() events.

### DIFF
--- a/src/core/FFmpeg.js
+++ b/src/core/FFmpeg.js
@@ -58,8 +58,8 @@ class FFmpeg extends Duplex {
     this._copy(['write', 'end'], this._writer);
     this._copy(['read', 'setEncoding', 'pipe', 'unpipe'], this._reader);
 
-    for (const method of ['on', 'once', 'removeListener', 'removeListeners', 'listeners']) {
-      this[method] = (ev, fn) => EVENTS[ev] ? EVENTS[ev][method](ev, fn) : Duplex.prototype[method].call(this, ev, fn);
+    for (const method of ['on', 'once', 'removeListener', 'removeListeners', 'listeners', 'emit') {
+      this[method] = (ev, ...fn) => EVENTS[ev] ? EVENTS[ev][method](ev, ...fn) : Duplex.prototype[method].call(this, ev, ...fn);
     }
 
     const processError = error => this.emit('error', error);

--- a/src/core/FFmpeg.js
+++ b/src/core/FFmpeg.js
@@ -42,7 +42,7 @@ class FFmpeg extends Duplex {
    */
   constructor(options = {}) {
     super();
-    this.process = FFmpeg.create({ shell: false, ...options });
+    this.process = FFmpeg.create({ shell: false, output: "pipe:1", ...options });
     const EVENTS = {
       readable: this._reader,
       data: this._reader,
@@ -151,9 +151,9 @@ class FFmpeg extends Duplex {
    * @private
    * @throws Will throw an error if FFmpeg cannot be found.
    */
-  static create({ args = [], shell = false } = {}) {
+  static create({ args = [], shell = false, output = "pipe:1" } = {}) {
     if (!args.includes('-i')) args.unshift('-i', '-');
-    return ChildProcess.spawn(FFmpeg.getInfo().command, args.concat(['pipe:1']), { windowsHide: true, shell });
+    return ChildProcess.spawn(FFmpeg.getInfo().command, args.concat([output]), { windowsHide: true, shell });
   }
 }
 

--- a/src/core/FFmpeg.js
+++ b/src/core/FFmpeg.js
@@ -58,7 +58,7 @@ class FFmpeg extends Duplex {
     this._copy(['write', 'end'], this._writer);
     this._copy(['read', 'setEncoding', 'pipe', 'unpipe'], this._reader);
 
-    for (const method of ['on', 'once', 'removeListener', 'removeListeners', 'listeners', 'emit') {
+    for (const method of ['on', 'once', 'removeListener', 'removeListeners', 'listeners', 'emit']) {
       this[method] = (ev, ...fn) => EVENTS[ev] ? EVENTS[ev][method](ev, ...fn) : Duplex.prototype[method].call(this, ev, ...fn);
     }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -8,6 +8,7 @@ import { vorbis } from './vorbis';
 
 export interface FFmpegOptions {
   args?: string[];
+  output?: string;
   shell?: boolean;
 }
 


### PR DESCRIPTION
This pr adds a new option `output` that lets you override the default `pipe:1` output. (to output to an RTP stream, file, etc)

It also fixes events manually emitted with `FFmpeg.emit()` not being passed to the proper stream.